### PR TITLE
fix: Check `getThemeInfo` existence

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,7 @@
 #     bsu_main_color <- "#1f78b4"
 #
 #     # Check Theme: If Dark, Update Colors
-#     if (rstudioapi::isAvailable()) {
+#     if (rstudioapi::isAvailable() && rstudioapi::hasFun("getThemeInfo")) {
 #         tryCatch({
 #             theme <- rstudioapi::getThemeInfo()
 #         })


### PR DESCRIPTION
In VS Code, loading `correlationfunnel` will raise error because of `rstudioapi::getThemeInfo()`
```R
r$> library(correlationfunnel)
Error: package or namespace load failed for ‘correlationfunnel’:
 .onAttach failed in attachNamespace() for 'correlationfunnel', details:
  call: rstudioapi::getThemeInfo()
  error: This {rstudioapi} function is not currently implemented for VSCode.
```
While R extension in VS Code has supported some of `rstudioapi` functions, `getThemeInfo()` is not included. Add `rstudioapi::hasFun("getThemeInfo")` besides `rstudioapi::isAvailable()` will solve the error
```R
r$> rstudioapi::isAvailable()
[1] TRUE

r$> rstudioapi::hasFun("getThemeInfo")
[1] FALSE
```
